### PR TITLE
bugfix: change watch using SubscribersCount

### DIFF
--- a/server/reporter/weekly.go
+++ b/server/reporter/weekly.go
@@ -63,7 +63,7 @@ func (r *Reporter) construcWeekReport() (WeekReport, error) {
 		return wr, err
 	}
 
-	wr.Watch = *(repo.WatchersCount)
+	wr.Watch = *(repo.SubscribersCount)
 	wr.Star = *(repo.StargazersCount)
 	wr.Fork = *(repo.ForksCount)
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

fix #4 

To address the following the API update of github.

> We recently changed the Watcher behavior on GitHub. What used to be known as "Watching" is now "Starring". Starring is basically a way to bookmark interesting repositories. Watching is a way to indicate that you want to receive email or web notifications on a Repository.

Thanks a lot for @zhuangqh 's advice.