### PR TITLE
processor: Add ping

### DIFF
--- a/server/processor/processor.go
+++ b/server/processor/processor.go
@@ -77,7 +77,8 @@ func (p *Processor) HandleEvent(eventType string, data []byte) error {
 			p.PRCommentProcessor.Process(data)
 			return nil
 		}
-		return nil
+	case "ping":
+		logrus.Debug("Got ping from GitHub")
 	default:
 		return fmt.Errorf("unknown event type %s", eventType)
 	}


### PR DESCRIPTION
When added the webhook to GitHub, it sends a `ping` request to test if the webhook works. Now the request returns 500 but actually the webhook handler works well.