### PR TITLE
bugfix: misunderstand the number of items perpage

### DIFF
--- a/server/gh/client.go
+++ b/server/gh/client.go
@@ -2,6 +2,7 @@ package gh
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/google/go-github/github"
@@ -18,13 +19,16 @@ type Client struct {
 
 // NewClient constructs a new instance of Client.
 func NewClient(owner, repo, token string) *Client {
-	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{
-			AccessToken: token,
-		},
-	)
-	tc := oauth2.NewClient(ctx, ts)
+	var tc *http.Client
+	if token != "" {
+		ctx := context.Background()
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{
+				AccessToken: token,
+			},
+		)
+		tc = oauth2.NewClient(ctx, ts)
+	}
 
 	return &Client{
 		Client: github.NewClient(tc),

--- a/server/gh/issues.go
+++ b/server/gh/issues.go
@@ -181,8 +181,7 @@ func (c *Client) SearchIssues(query string, opt *github.SearchOptions, all bool)
 		opt.PerPage = 30
 	}
 
-	total := 0
-	issueSearchResult := &github.IssuesSearchResult{Total: &total}
+	issueSearchResult := &github.IssuesSearchResult{}
 
 	for {
 		result, resp, err := c.Search.Issues(context.Background(), query, opt)
@@ -193,7 +192,7 @@ func (c *Client) SearchIssues(query string, opt *github.SearchOptions, all bool)
 		if result.Total == nil {
 			break
 		}
-		total += *result.Total
+		issueSearchResult.Total = result.Total
 		issueSearchResult.Issues = append(issueSearchResult.Issues, result.Issues...)
 
 		// just retrieve a page.


### PR DESCRIPTION
Signed-off-by: jerryzhuang zhuangqhc@gmail.com

**Ⅰ. Describe what this PR did**
The number of merged PR report by pouchrobot is different from expectations. This PR correct how to compute total number of merged PR.

**Ⅱ. Does this pull request fix one issue?**

**Ⅲ. Describe how you did it**

**Ⅳ. Describe how to verify it**

run this test code and compare it with the result from website toolbar manually.

```go
package main

import (
	"fmt"
	"github.com/pouchcontainer/pouchrobot/server/gh"
)

var (
	repo = "pouch"
	owner = "alibaba"
)

func main() {
	ghClient := gh.NewClient(owner, repo, "")

	checkMergedPRFromDate(ghClient, "2018-05-14")
	checkMergedPRFromDate(ghClient, "2018-05-21")
}

func checkMergedPRFromDate(client *gh.Client, date string) {
	query := fmt.Sprintf("is:merged type:pr repo:%s/%s merged:>=%s", owner, repo, date)
	issueSearchResult, err := client.SearchIssues(query, nil, true)
	if err != nil {
		fmt.Println("fail to do request")
		return
	}

	fmt.Printf("%v merged pr since %s, actually get %v items\n",
		issueSearchResult.GetTotal(), date, len(issueSearchResult.Issues))
}
```

**Ⅴ. Special notes for reviews**