### PR TITLE
feature: specific label for special issue

### DIFF
--- a/server/processor/issueProcessor/open/labels.go
+++ b/server/processor/issueProcessor/open/labels.go
@@ -30,7 +30,15 @@ func ParseToGenerateLabels(issue *github.Issue) []string {
 	labels = append(labels, ParseTitleToGenerateLabels(issue)...)
 	labels = append(labels, ParseBodyToGenerateLabels(issue)...)
 
-	return utils.UniqueElementSlice(labels)
+	labels = utils.UniqueElementSlice(labels)
+
+	for _, label := range labels {
+		if specificLabels, ok := utils.SpecialIssueMatches[label]; ok {
+			return specificLabels
+		}
+	}
+
+	return labels
 }
 
 // ParseTitleToGenerateLabels parses issue title to generate a slice.

--- a/server/utils/matches.go
+++ b/server/utils/matches.go
@@ -192,3 +192,11 @@ var BodyMatches = map[string][]string{
 		"invalid memory address or nil pointer",
 	},
 }
+
+// SpecialIssueMatches is a map in which key is the label, and value is a slice of labels
+// which will be specifically attached to those issues which contain this key.
+var SpecialIssueMatches = map[string][]string{
+	"WeeklyReport": []string{
+		"WeeklyReport",
+	},
+}


### PR DESCRIPTION
Signed-off-by: zhuangqh <zhuangqhc@163.com>

**Ⅰ. Describe what this PR did**
specific label for special issue.

For example, pouchrobot will attach exactly one label "WeeklyReport" to the issue which is a weekly report.