### PR TITLE
feature: add created and closed issue statistics in weekly report

### DIFF
--- a/server/reporter/reporter.go
+++ b/server/reporter/reporter.go
@@ -36,7 +36,7 @@ func New(client *gh.Client) *Reporter {
 // Run starts to work on reporting things for repo.
 func (r *Reporter) Run() {
 	logrus.Infof("start to run reporter")
-	// Wait time goes to Monday.
+	// Wait time goes to Thursday.
 	for {
 		if time.Now().Weekday().String() == "Thursday" {
 			if hour, _, _ := time.Now().Clock(); hour == 8 {

--- a/server/reporter/weekly.go
+++ b/server/reporter/weekly.go
@@ -42,6 +42,12 @@ type WeekReport struct {
 	// Fork defines currently how many github users have forked this repo.
 	Fork int
 
+	// NumOfNewIssues is the issues number which are created in the last week.
+	NumOfNewIssues int
+
+	// NumOfClosedIssues is the issues number which are closed in the last week.
+	NumOfClosedIssues int
+
 	// ContributorsCount defines the number of contributors.
 	ContributorsCount int
 
@@ -102,8 +108,13 @@ func (r *Reporter) constructWeekReport() (WeekReport, error) {
 	wr.Star = *(repo.StargazersCount)
 	wr.Fork = *(repo.ForksCount)
 
-	// get merged pull request details
+	// get new issues and closed issue in the last week
+	newIssues, err := r.client.GetIssues(&github.IssueListByRepoOptions{Since: lastWeek})
+	if err != nil {
+		logrus.Errorf("failed to get open")
+	}
 
+	// get merged pull request details
 	logrus.Infof("Start: %s, End: %s", wr.StartDate, wr.EndDate)
 	query := fmt.Sprintf("is:merged type:pr repo:%s/%s merged:>=%s", r.client.Owner(), r.client.Repo(), wr.StartDate)
 	issueSearchResult, err := r.client.SearchIssues(query, nil, true)
@@ -186,28 +197,53 @@ func (wr *WeekReport) String() string {
 
 This is a weekly report of PouchContainer. It summarizes what have changed in PouchContainer in the passed week, including pr merged, new contributors, and more things in the future. 
 It is all done by @pouchrobot which is an AI robot.
+`)
 
-## Repo Update
+	// get repo update for this week
+	repoUpdateContent := wr.getRepoUpdateContent()
+	totalStr += repoUpdateContent
 
-| Type      |    Count |
-| :-------- | --------:|
-| Watch     |   %d |
-| Star      |   %d |
-| Fork      |   %d |
-`,
-		wr.Watch,
-		wr.Star,
-		wr.Fork,
-	)
+	// get repo update for this week
+	prUpdateContent := wr.getPRUpdateContent()
+	totalStr += prUpdateContent
 
-	prUpdateSubStr := fmt.Sprintf(`
-## PR Update
+	// construct code review details of the past week
+	prReviewContent := wr.getPRReviewContent()
+	totalStr += prReviewContent
 
-Thanks to contributions from community, PouchContainer team merged %d pull requests in the PouchContainer repositories last week. All these pull requests could be divided into **feature**, **bugfix**, **doc**, **test** and **others**:
+	// calculate new contributors of this week.
+	newContributorsContent := wr.getNewContributorsContent()
+	totalStr += newContributorsContent
 
-`,
-		wr.CountOfPR,
-	)
+	return totalStr
+}
+
+func (wr *WeekReport) getRepoUpdateContent() string {
+	header := "## Repo Update \n"
+
+	foreword := ""
+
+	repoUpdate := `
+| Watch | Star | Fork | New Issues | Closed Issues |
+|:-----:|:----:|:----:|:----------:|:-------------:|
+`
+	repoUpdate += fmt.Sprintf("|%d|%d|%d|%d|%d|\n\n", wr.Watch, wr.Star, wr.Fork, wr.NumOfNewIssues, wr.NumOfClosedIssues)
+
+	wholeContent := header + foreword + repoUpdate
+	return wholeContent
+}
+
+func (wr *WeekReport) getPRUpdateContent() string {
+	header := fmt.Sprintf(`
+		## PR Update
+		
+		Thanks to contributions from community, PouchContainer team merged %d pull requests in the PouchContainer repositories last week. All these pull requests could be divided into **feature**, **bugfix**, **doc**, **test** and **others**:
+		
+		`, wr.CountOfPR)
+
+	foreword := ""
+
+	prUpdateContent := ""
 	for _, typeStr := range []string{"feature", "bugfix", "doc", "test", "others"} {
 		if len(wr.MergedPR[typeStr]) == 0 {
 			// if no this type pr merged, no related thing output.
@@ -226,40 +262,16 @@ Thanks to contributions from community, PouchContainer team merged %d pull reque
 		} else {
 			appendStr = fmt.Sprintf("### %s\n\n", typeStr)
 		}
-		prUpdateSubStr = prUpdateSubStr + appendStr
+
+		prUpdateContent += appendStr
 		for _, pr := range wr.MergedPR[typeStr] {
-			prUpdateSubStr = prUpdateSubStr + fmt.Sprintf("* %s ([#%d](%s))\n", pr.Title, pr.Num, pr.HTMLURL)
+			prUpdateContent += fmt.Sprintf("* %s ([#%d](%s))\n", pr.Title, pr.Num, pr.HTMLURL)
 		}
-		prUpdateSubStr = prUpdateSubStr + "\n"
-	}
-	totalStr = totalStr + prUpdateSubStr
-
-	// construct code review details of the past week
-	prReviewContent := wr.getPRReviewContent()
-	totalStr += prReviewContent
-
-	// calculate new contributors of this week.
-	newContribSubstr := "## New Contributors 🎖 🎖 🎖 \n\n"
-	if len(wr.NewContributors) != 0 {
-		newContribSubstr = newContribSubstr + `It is PouchContainer team's great honor to have new contributors in Pouch's community. We really appreciate your contributions. Feel free to tell us if you have any opinion and please share PouchContainer with more people if you could. If you hope to be a contributor as well, please start from https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md . 🎁 👏 🍺
-
-Here is the list of new contributors:
-
-`
-		for _, contributor := range wr.NewContributors {
-			newContribSubstr = newContribSubstr + fmt.Sprintf("@%s\n", contributor)
-		}
-	} else {
-		newContribSubstr = newContribSubstr + `We have no new contributors in PouchContainer project this week.
-PouchContainer team encourages everything about contribution from community.
-For more details, please refer to https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md . 🍻
-`
+		prUpdateContent += "\n"
 	}
 
-	newContribSubstr = newContribSubstr + fmt.Sprintf("\n\n Thank all of you!")
-	totalStr = totalStr + newContribSubstr
-
-	return totalStr
+	wholeContent := header + foreword + prUpdateContent
+	return wholeContent
 }
 
 func (wr *WeekReport) getPRReviewContent() string {
@@ -299,5 +311,31 @@ func (wr *WeekReport) getPRReviewContent() string {
 	tableContent += "\n\n"
 
 	wholeContent := header + foreword + tableHeader + tableContent
+	return wholeContent
+}
+
+func (wr *WeekReport) getNewContributorsContent() string {
+	header := "## New Contributors 🎖 🎖 🎖 \n\n"
+
+	newContributorsContent := ""
+	if len(wr.NewContributors) != 0 {
+		newContributorsContent += `It is PouchContainer team's great honor to have new contributors in Pouch's community. We really appreciate your contributions. Feel free to tell us if you have any opinion and please share PouchContainer with more people if you could. If you hope to be a contributor as well, please start from https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md . 🎁 👏 🍺
+
+Here is the list of new contributors:
+
+`
+		for _, contributor := range wr.NewContributors {
+			newContributorsContent += fmt.Sprintf("@%s\n", contributor)
+		}
+	} else {
+		newContributorsContent += `We have no new contributors in PouchContainer project this week.
+PouchContainer team encourages everything about contribution from community.
+For more details, please refer to https://github.com/alibaba/pouch/blob/master/CONTRIBUTING.md . 🍻
+`
+	}
+
+	newContributorsContent += fmt.Sprintf("\n\n Thank all of you!")
+
+	wholeContent := header + newContributorsContent
 	return wholeContent
 }


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

according to @Letty5411 's demand, we need to add number of created and closed issue in weekly report. This PR handles this.

In addition, split some codes to encapsulate functions.