### PR TITLE
Close the issues without an update in a time 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	Repo        string
 	HTTPListen  string
 	AccessToken string
+	Timeunit	string
+	Time        int
 }
 
 // NewConfig creates a
@@ -28,5 +30,7 @@ func NewConfig() Config {
 		Owner:      "",
 		Repo:       "",
 		HTTPListen: "",
+		Timeunit: 	"s",
+		Time:		1,
 	}
 }

--- a/fetcher/check_issue.go
+++ b/fetcher/check_issue.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The Pouch Robot Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetcher
+
+import (
+
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"time"
+	"context"
+)
+
+// CheckPRsConflict checks that if a PR is conflict with the against branch.
+func (f *Fetcher) CheckIssue() error {
+	logrus.Info("start to check timeout issue")
+	opt := &github.IssueListByRepoOptions{
+		State: "open",
+	}
+	prs, err := f.client.GetIssues(opt)
+	if err != nil {
+		return err
+	}
+
+	for _, pr := range prs {
+		f.checkIssue(pr)
+	}
+	return nil
+}
+
+func (f *Fetcher) checkIssue(p *github.Issue) error {
+
+	// if PR can be merged to specified branch
+	now := time.Now()
+	dur, _ := time.ParseDuration("-1s")
+	checkLine := now.Add(dur)
+	close := "close"
+	if p != nil && p.GetUpdatedAt().Before(checkLine){
+		// just remove conflict label if there is one
+		// and remove conflict comments if there are some
+		logrus.Infof("No #%d issue is closed!!", *p.Number)
+		issue := github.IssueRequest{
+			State : &close,
+		}
+		_, _, error := f.client.Issues.Edit(context.Background(), "paul-yml", "testrobot", *p.Number, &issue)
+		if error != nil {
+			logrus.Error("lock error %v", error)
+		}
+		return nil
+	}
+
+	//logrus.Infof("PR %d: found conflict", *(pr.Number))
+	//// remove LGTM label if conflict happens
+	//if f.client.IssueHasLabel(*(pr.Number), "LGTM") {
+	//	f.client.RemoveLabelForIssue(*(pr.Number), "LGTM")
+	//}
+	//
+	//// attach a label and add comments
+	//if !f.client.IssueHasLabel(*(pr.Number), utils.PRConflictLabel) {
+	//	f.client.AddLabelsToIssue(*(pr.Number), []string{utils.PRConflictLabel})
+	//}
+	// attach a comment to the pr,
+	// and attach a lable confilct/need-rebase to pr
+
+	return nil
+
+}

--- a/fetcher/check_issue.go
+++ b/fetcher/check_issue.go
@@ -41,37 +41,23 @@ func (f *Fetcher) CheckIssue() error {
 
 func (f *Fetcher) checkIssue(p *github.Issue) error {
 
-	// if PR can be merged to specified branch
 	now := time.Now()
-	dur, _ := time.ParseDuration("-1s")
-	checkLine := now.Add(dur)
+
+	dur, _ := time.ParseDuration("-1" + f.client.TimeUnit())
+
+	checkLine := now.Add(time.Duration(int64(f.client.Time()) * dur.Nanoseconds()))
 	close := "close"
 	if p != nil && p.GetUpdatedAt().Before(checkLine){
-		// just remove conflict label if there is one
-		// and remove conflict comments if there are some
-		logrus.Infof("No #%d issue is closed!!", *p.Number)
+		logrus.Infof("No #%d issue is closed!! time %v %s", *p.Number,f.client.Time(), f.client.TimeUnit())
 		issue := github.IssueRequest{
 			State : &close,
 		}
-		_, _, error := f.client.Issues.Edit(context.Background(), "paul-yml", "testrobot", *p.Number, &issue)
+		_, _, error := f.client.Issues.Edit(context.Background(), f.client.Owner(), f.client.Repo(), *p.Number, &issue)
 		if error != nil {
 			logrus.Error("lock error %v", error)
 		}
 		return nil
 	}
-
-	//logrus.Infof("PR %d: found conflict", *(pr.Number))
-	//// remove LGTM label if conflict happens
-	//if f.client.IssueHasLabel(*(pr.Number), "LGTM") {
-	//	f.client.RemoveLabelForIssue(*(pr.Number), "LGTM")
-	//}
-	//
-	//// attach a label and add comments
-	//if !f.client.IssueHasLabel(*(pr.Number), utils.PRConflictLabel) {
-	//	f.client.AddLabelsToIssue(*(pr.Number), []string{utils.PRConflictLabel})
-	//}
-	// attach a comment to the pr,
-	// and attach a lable confilct/need-rebase to pr
 
 	return nil
 

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -44,6 +44,7 @@ func (f *Fetcher) Run() {
 	for {
 		f.CheckPRsConflict()
 		f.CheckPRsGap()
+		f.CheckIssue()
 		time.Sleep(FETCHINTERVAL)
 	}
 }

--- a/gh/client.go
+++ b/gh/client.go
@@ -29,10 +29,12 @@ type Client struct {
 	*github.Client
 	owner string
 	repo  string
+	timeUnit string
+	time int
 }
 
 // NewClient constructs a new instance of Client.
-func NewClient(owner, repo, token string) *Client {
+func NewClient(owner, repo, timeUnit string, time int, token string) *Client {
 	var tc *http.Client
 	if token != "" {
 		ctx := context.Background()
@@ -48,6 +50,8 @@ func NewClient(owner, repo, token string) *Client {
 		Client: github.NewClient(tc),
 		owner:  owner,
 		repo:   repo,
+		timeUnit: timeUnit,
+		time: time,
 	}
 }
 
@@ -63,4 +67,18 @@ func (c *Client) Repo() string {
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
 	return c.repo
+}
+
+// Repo returns repo name of client.
+func (c *Client) TimeUnit() string {
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+	return c.timeUnit
+}
+
+// Repo returns repo name of client.
+func (c *Client) Time() int {
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+	return c.time
 }

--- a/gh/issues.go
+++ b/gh/issues.go
@@ -16,7 +16,6 @@ package gh
 
 import (
 	"context"
-
 	"github.com/pouchcontainer/pouchrobot/utils"
 
 	"github.com/google/go-github/github"
@@ -51,7 +50,21 @@ func (c *Client) CreateIssue(title, body string) error {
 	}
 	return nil
 }
+// Remove issue
+func (c *Client) LockIssue(num int) error {
 
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+	_, resp, error :=c.Authorizations.Check(context.Background(),"cb7de59bf75b5edf903f","aec551e22249dd32550585bafce3b65146e1d880")
+	if error != nil {
+		logrus.Errorf("auth faild %v", error)
+	}
+	logrus.Info("res: %v", resp)
+	if _, err := c.Issues.Lock(context.Background(), "paul-yml", "testrobot", num); err != nil {
+		logrus.Errorf("failed to create issue in repo %s: %v", num, err)
+	}
+	return nil
+}
 // GetAllLabels gets all labels of a repo, not an issue, nor a pull request
 func (c *Client) GetAllLabels() ([]*github.Label, error) {
 	c.Mutex.Lock()

--- a/gh/issues.go
+++ b/gh/issues.go
@@ -55,7 +55,7 @@ func (c *Client) LockIssue(num int) error {
 
 	c.Mutex.Lock()
 	defer c.Mutex.Unlock()
-	_, resp, error :=c.Authorizations.Check(context.Background(),"cb7de59bf75b5edf903f","aec551e22249dd32550585bafce3b65146e1d880")
+	_, resp, error :=c.Authorizations.Check(context.Background(),"paul-yml","a52bd035bb0210bd173db996e96d91b7453b42da")
 	if error != nil {
 		logrus.Errorf("auth faild %v", error)
 	}

--- a/main.go
+++ b/main.go
@@ -15,10 +15,9 @@
 package main
 
 import (
-	"github.com/pouchcontainer/pouchrobot/config"
-
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/sirupsen/logrus"
+	"github.com/pouchcontainer/pouchrobot/config"
 )
 
 func main() {
@@ -33,10 +32,10 @@ func main() {
 	}
 
 	flagSet := cmdServe.Flags()
-	flagSet.StringVarP(&cfg.Owner, "owner", "o", "", "github ID to which connect in GitHub")
-	flagSet.StringVarP(&cfg.Repo, "repo", "r", "", "github repo to which connect in GitHub")
+	flagSet.StringVarP(&cfg.Owner, "owner", "o", "paul-yml", "github ID to which connect in GitHub")
+	flagSet.StringVarP(&cfg.Repo, "repo", "r", "testrobot", "github repo to which connect in GitHub")
 	flagSet.StringVarP(&cfg.HTTPListen, "listen", "l", "", "where does automan listened on")
-	flagSet.StringVarP(&cfg.AccessToken, "token", "t", "", "access token to have some control on resources")
+	flagSet.StringVarP(&cfg.AccessToken, "token", "t", "afdc4a6aef1d2bcdbdca3b3d69ac301a1095444a", "access token to have some control on resources")
 
 	cmdServe.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ func main() {
 	flagSet.StringVarP(&cfg.Owner, "owner", "o", "paul-yml", "github ID to which connect in GitHub")
 	flagSet.StringVarP(&cfg.Repo, "repo", "r", "testrobot", "github repo to which connect in GitHub")
 	flagSet.StringVarP(&cfg.HTTPListen, "listen", "l", "", "where does automan listened on")
-	flagSet.StringVarP(&cfg.AccessToken, "token", "t", "afdc4a6aef1d2bcdbdca3b3d69ac301a1095444a", "access token to have some control on resources")
-
+	flagSet.StringVarP(&cfg.AccessToken, "token", "t", "0a3417b3958a91349625ba0b5d4f4d224ff34d86", "access token to have some control on resources")
+	flagSet.StringVarP(&cfg.Timeunit, "timeunit", "u","s", "m for minute, d for day, s for second")
+	flagSet.IntVarP(&cfg.Time, "time", "n",1, "use with u, -u d -n 5 means closed issues with out update in 5 days")
 	cmdServe.Execute()
 }

--- a/server.go
+++ b/server.go
@@ -19,16 +19,16 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pouchcontainer/pouchrobot/ci"
-	"github.com/pouchcontainer/pouchrobot/config"
-	"github.com/pouchcontainer/pouchrobot/docgenerator"
-	"github.com/pouchcontainer/pouchrobot/fetcher"
-	"github.com/pouchcontainer/pouchrobot/gh"
-	"github.com/pouchcontainer/pouchrobot/processor"
-	"github.com/pouchcontainer/pouchrobot/reporter"
-
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+
+	"github.com/pouchcontainer/pouchrobot/fetcher"
+	"github.com/pouchcontainer/pouchrobot/ci"
+	"github.com/pouchcontainer/pouchrobot/reporter"
+	"github.com/pouchcontainer/pouchrobot/docgenerator"
+	"github.com/pouchcontainer/pouchrobot/gh"
+	"github.com/pouchcontainer/pouchrobot/processor"
+	"github.com/pouchcontainer/pouchrobot/config"
 )
 
 // DefaultAddress is the default address daemon will listen to.
@@ -52,7 +52,7 @@ type Server struct {
 
 // NewServer constructs a brand new automan server
 func NewServer(config config.Config) *Server {
-	ghClient := gh.NewClient(config.Owner, config.Repo, config.AccessToken)
+	ghClient := gh.NewClient(config.Owner, config.Repo, config.Timeunit, config.Time, config.AccessToken)
 	return &Server{
 		listenAddress: config.HTTPListen,
 		processor:     processor.New(ghClient),


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
There is a executable file mai in the directory
User need to get a token from GitHub setting before use, one token can be used in one time
close the issues without update in 5 seconds, the default of the two parameters is 1 second
### Ⅱ. Does this pull request fix one issue?
fix #30
### Ⅲ. Describe how you did it
Add a new check_issue in fetcher, modify the config, main
There are  two more parameters, -u -n, u is time unit, -n is time, for example, ./mai -u s -n 5 means 
### Ⅳ. Describe how to verify it
get a new Token, "abcdefg" username is user, repo is poj, delete issues without update 30 days the cmd is:
./mai -o user -r poj -t abcdef -u d -t 30
and then the issues in the repo will be closed 
### Ⅴ. Special notes for reviews