### PR TITLE
fix: add conflict handling block to erase check_gap stuck

### DIFF
--- a/fetcher/check_gap.go
+++ b/fetcher/check_gap.go
@@ -38,51 +38,46 @@ func (f *Fetcher) CheckPRsGap() error {
 		return err
 	}
 
+	// get master branch info
+	if err := prepareMasterEnv(); err != nil {
+		return err
+	}
+	logrus.Infof("prepare master env done")
+
+	msLogString, err := getLogInfo("master")
+	if err != nil {
+		return fmt.Errorf("failed to get master log info: %v", err)
+	}
+	logrus.Infof("get log info of master branch done")
+
 	for _, pr := range prs {
 		logrus.Info("start to check prs")
-		go func(pr *github.PullRequest) {
-			if err := f.checkPRGap(pr); err != nil {
-				logrus.Errorf("failed to check pull request %d gap: %v", *pr.Number, err)
-			}
-		}(pr)
+		if err := f.checkPRGap(pr, msLogString); err != nil {
+			logrus.Errorf("failed to check pull request %d gap: %v", *pr.Number, err)
+		}
 	}
 	return nil
 }
 
-func (f *Fetcher) checkPRGap(p *github.PullRequest) error {
+func (f *Fetcher) checkPRGap(p *github.PullRequest, msLogString string) error {
 	pr, err := f.client.GetSinglePR(*(p.Number))
 	logrus.Infof("start to check pr %d", *(p.Number))
 	if err != nil {
 		return err
 	}
 
-	// get master branch info
-	if err := prepareMasterEnv(); err != nil {
-		return err
-	}
-	logrus.Infof("prepare master env done :pr %d", *(p.Number))
-
-	msLogString, err := getLogInfo("master")
-	if err != nil {
-		return err
-	}
-	logrus.Infof("get log info done :pr %d", *(p.Number))
-
 	// get pr branch info
 	prNum := strconv.Itoa(*p.Number)
 
-	// FIXME handle the situation when failed to clean existing pr branch.
-	cleanPrBranchEnv(prNum)
-	logrus.Infof("clean exsiting branch done:pr %d", *(p.Number))
-
 	if err = preparePrBranchEnv(prNum); err != nil {
-		return err
+		handlePrConflict()
+		return fmt.Errorf("failed to prepare pr branch: %v", err)
 	}
 	logrus.Infof("prepare pr branch env done :pr %d", *(p.Number))
 
-	prBrLogString, err := getLogInfo("pr branch " + prNum)
+	prBrLogString, err := getLogInfo("new-" + prNum)
 	if err != nil {
-		logrus.Error(err)
+		logrus.Errorf("failed to get master log info: %v", err)
 		return err
 	}
 	logrus.Infof("get pr log info done :pr %d", *(p.Number))
@@ -184,26 +179,31 @@ func preparePrBranchEnv(prNum string) error {
 		return fmt.Errorf("failed to pull pr %s: %v", prNum, err)
 	}
 
-	cmd = exec.Command("git", "checkout", "new-"+prNum)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to checkout pr %s branch: %v", prNum, err)
-	}
-
 	return nil
 }
 
-func cleanPrBranchEnv(prNum string) error {
-	cmd := exec.Command("git", "branch", "-D", "new-"+prNum)
-	// TODO ignore not found error
+func handlePrConflict() error {
+	cmd := exec.Command("git", "reset", "--hard", "HEAD^")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to remove existing pr %s branch %v", prNum, err)
+		return fmt.Errorf("failed to reset HEAD: %v", err)
 	}
-	return nil
-}
 
+	cmd = exec.Command("git", "fetch", "upstream", "master")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to git fetch upstream master: %v", err)
+	}
+
+	cmd = exec.Command("git", "rebase", "upstream/master")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to git rebase upstream/master: %v", err)
+	}
+
+	return nil
+
+}
 func getLogInfo(branch string) (string, error) {
 	var Out bytes.Buffer
-	cmd := exec.Command("git", "log", "--oneline")
+	cmd := exec.Command("git", "log", branch, "--oneline")
 	cmd.Stdout = &Out
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("failed to get %s log: %v", branch, err)


### PR DESCRIPTION
Signed-off-by: Zou Rui <21751189@zju.edu.cn>

This pr fixes the problem that the failure of ```git pull ../.../head``` on one pr will block all the follow-up gap checking work.
And it is done by adding an error-fixing block. Once the merging conflict happens, it calls ``` handlePrConflict()``` to erase the conflict in HEAD.