### PR TITLE
bugfix: make cmd execution show more output

### DIFF
--- a/docgenerator/api.go
+++ b/docgenerator/api.go
@@ -51,8 +51,8 @@ func (g *Generator) generateAPIDoc() error {
 		swagger2markupConfig,
 	}
 	cmd := exec.Command("java", args...)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to use swagger2markdown to generate API docs: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to use swagger2markdown to generate API docs: output(%s), err(%v)", string(data), err)
 	}
 	return nil
 }

--- a/docgenerator/cli.go
+++ b/docgenerator/cli.go
@@ -29,14 +29,14 @@ import (
 func (g *Generator) generateCliDoc() error {
 	// build a new pouch cli client, since all cli doc is from newly built cli.
 	cmd := exec.Command("make", "build-cli")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to make client: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to make client: output(%s), err(%v)", string(data), err)
 	}
 
 	// auto generate cli docs
 	cmd = exec.Command("./bin/pouch", "gen-doc")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to gen doc via cobra: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to gen doc via cobra: output(%s), err(%v)", string(data), err)
 	}
 
 	return nil

--- a/docgenerator/generator.go
+++ b/docgenerator/generator.go
@@ -133,33 +133,33 @@ func prepareGitEnv(newBranchName string) error {
 
 	// checkout local master branch
 	cmd := exec.Command("git", "checkout", "master")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to checkout master: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to checkout master: output(%s), err(%v)", string(data), err)
 	}
 
 	// fetch upstream master to local
 	cmd = exec.Command("git", "fetch", "upstream", "master")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git fetch upstreanm master: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git fetch upstreanm master: output(%s), err(%v)", string(data), err)
 	}
 
 	// rebase local master on origin/master
 	cmd = exec.Command("git", "rebase", "upstream/master")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git rebase upstreanm/master: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git rebase upstreanm/master:output(%s), err(%v)", string(data), err)
 	}
 
 	// push local master to origin/master
 	cmd = exec.Command("git", "push", "-f", "origin", "master")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git push -f origin master: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git push -f origin master: output(%s), err(%v)", string(data), err)
 	}
 
 	// create a new branch named by input newBranchName
 	// the following doc generation are all on this new branch
 	cmd = exec.Command("git", "checkout", "-b", newBranchName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git checkout -b %s: %v", newBranchName, err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git checkout -b %s: output(%s), err(%v)", newBranchName, string(data), err)
 	}
 	return nil
 }
@@ -167,8 +167,8 @@ func prepareGitEnv(newBranchName string) error {
 func gitCommitAndPush(newBranchName string) error {
 	// git add all updated files.
 	cmd := exec.Command("git", "add", ".")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git add .: %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git add .: output(%s), err(%v)", string(data), err)
 	}
 
 	// check whether nothing changed.
@@ -185,26 +185,26 @@ func gitCommitAndPush(newBranchName string) error {
 
 	// git commit all the staged files.
 	cmd = exec.Command("git", "commit", "-s", "-m", "docs: auto generate pouch cli docs via code")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git commit -s -m : %v", err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git commit -s -m : output(%s), err(%v)", string(data), err)
 	}
 
 	// git push forcely to origin repo.
 	cmd = exec.Command("git", "push", "-f", "origin", newBranchName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git push -f origin %s: %v", newBranchName, err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git push -f origin %s: output(%s), err(%v)", newBranchName, string(data), err)
 	}
 
 	// git branch -D to delete branch to free resources.
 	cmd = exec.Command("git", "checkout", "master")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git checkout master before deleting branch %s: %v", newBranchName, err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git checkout master before deleting branch %s: output(%s), err(%v)", newBranchName, string(data), err)
 	}
 
 	// git branch -D to delete branch to free resources.
 	cmd = exec.Command("git", "branch", "-D", newBranchName)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to git push branch -D %s: %v", newBranchName, err)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to git push branch -D %s: output(%s), err(%v)", newBranchName, string(data), err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/pouchcontainer/pouchrobot/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

 make cmd execution show more output.

If we only use `cmd.Run`, it will take exit code non-zero as an error message. It is not so reasonable for logging and debugging. 

```
"failed to prepare git environment: failed to checkout master: exit status 128"
```


### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
no need


### Ⅳ. Describe how to verify it
none


### Ⅴ. Special notes for reviews
none

