### PR TITLE
Refactor command line params to json config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,25 +115,14 @@ Usage:
   An AI-based collaboration robot applied to open source project on GitHub [flags]
 
 Flags:
-      --api-doc-path string       specifies where to generate the doc file corresponding to swagger.yml
-  -c, --commits-gap int           commits gap between pull request and master branch; if the fact is beyond this number, requestto rebase (default 20)
-      --doc-generation-hour int   specifies doc generation hour of every day. (default 1)
-  -h, --help                      help for An
-  -l, --listen string             where does robot listen on
-  -o, --owner string              GitHub username to which this robot connects
-  -r, --repo string               GitHub code repository to which this robot connects
-      --report-day string         weekly report generation day of a week (default "Friday")
-      --report-hour int           weekly report generation hour on report-day (default 7)
-      --root-dir string           specifies repo's root directory which is to generated docs
-      --swagger-path string       specifies where the swagger.yml file locates
-  -t, --token string              access token which identifies robot username in GitHub having write access on repo
+  -c, --config string           Config file path for robot (default "config.json")
 ```
 
 pouchrobot is totally fitable in running a container. In this repo, we can find a Dockerfile to build the corresponding image. When finishing the building, the following command could help to setup a brand new robot:
 
-> pouch run -d -v /root/newssh:/root/.ssh -p 6789:6789 pouchrobot:v1.0 pouchrobot -o alibaba -r pouch -l 0.0.0.0:6789 --token TOKEN
+> pouch run -d -v /root/newssh:/root/.ssh -v /config:/root/config -p 6789:6789 pouchrobot:v1.0 --config /root/config/config.json
 
-In which TOKEN is a github token for a specific user.
+You can make your own config file by following the format of `config_template.json` file
 
 ## Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,56 +14,40 @@
 
 package config
 
-// Config refers
-type Config struct {
-	// Owner is the organization of open source project.
-	Owner string
-
-	// Repo is the repository name.
-	Repo string
-
-	// HTTPListen is the tcp address the robot listens on.
-	HTTPListen string
-
-	// AccessToken is identify which github user this robot plays the role.
-	AccessToken string
-
-	// Commits Gap is for fetcher to check commit gap between pr and master branch,
-	// if it is larger than CommitsGap, request to rebase this.
-	CommitsGap int
-
-	// For weekly reporter
-
-	// ReportDay representing which is the weekly report generation day.
-	ReportDay string
-
-	// ReportHour representing which is the weekly report generation time on ReportDay.
-	ReportHour int
-
-	// For doc generator
-
-	// RootDir specifies repo's rootdir which is to generated docs.
-	RootDir string
-
-	// SwaggerPath specifies where the swagger.yml file locates.
-	SwaggerPath string
-
-	// APIDocPath specifies where to generate the doc file corresponding to swagger.yml.
-	// this is a relative path to root dir.
-	APIDocPath string
-
-	// GenerationHour represents doc generation time every day.
-	// Valid range is [0, 23].
-	GenerationHour int
-
-	// BaiduTranslatorAppID is the appid for baidu translator init
-	BaiduTranslatorAppID string
-
-	// BaiduTranslatorKey is the appid for baidu translator init
-	BaiduTranslatorKey string
+// CmdConfig refers the start command line config needed
+type CmdConfig struct {
+	// ConfigFilePath is the path of config json file
+	ConfigFilePath string
 }
 
-// NewConfig creates a brand new Config instance with default values.
+// Config refers the config values for the project
+type Config struct {
+	// Owner is the organization of open source project.
+	Owner string `json:"owner"`
+
+	// Repo is the repository name.
+	Repo string `json:"repo"`
+
+	// HTTPListen is the tcp address the robot listens on.
+	HTTPListen string `json:"httpListen"`
+
+	// AccessToken is identify which github user this robot plays the role.
+	AccessToken string `json:"accessToken"`
+
+	// FetcherConfig is configs for fetcher module
+	FetcherConfig FetcherConfig `json:"fetcher"`
+
+	// DocGenerateConfig is configs for doc generate module
+	DocGenerateConfig DocGenerateConfig `json:"docGenerator"`
+
+	// TranslatorConfig is configs for translate module
+	TranslatorConfig TranslatorConfig `json:"translator"`
+
+	// WeeklyReportConfig is configs for weekly report module
+	WeeklyReportConfig WeeklyReportConfig `json:"weeklyReport"`
+}
+
+// NewConfig creates a brand new Config instance
 func NewConfig() Config {
 	return Config{}
 }

--- a/config/doc_generate.go
+++ b/config/doc_generate.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Pouch Robot Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// DocGenerateConfig refers to doc auto generate config
+type DocGenerateConfig struct {
+	// RootDir specifies repo's rootdir which is to generated docs.
+	RootDir string `json:"rootDir"`
+
+	// SwaggerPath specifies where the swagger.yml file locates.
+	SwaggerPath string `json:"swaggerPath"`
+
+	// APIDocPath specifies where to generate the doc file corresponding to swagger.yml.
+	// this is a relative path to root dir.
+	APIDocPath string `json:"APIDocPath"`
+
+	// GenerationHour represents doc generation time every day.
+	// Valid range is [0, 23].
+	GenerationHour int `json:"generationHour"`
+}

--- a/config/fetcher.go
+++ b/config/fetcher.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The Pouch Robot Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// FetcherConfig refers to doc auto generate config
+type FetcherConfig struct {
+	// Commits Gap is for fetcher to check commit gap between pr and master branch,
+	// if it is larger than CommitsGap, request to rebase this.
+	CommitsGap int `json:"commitsGap"`
+}

--- a/config/translator.go
+++ b/config/translator.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Pouch Robot Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// TranslatorConfig refers to auto translate config
+type TranslatorConfig struct {
+	// BaiduConfig is the config for baidu based translator
+	BaiduConfig BaiduTranslateConfig `json:"baidu"`
+}
+
+// BaiduTranslateConfig refers to Baidu API based translate config
+type BaiduTranslateConfig struct {
+	// AppID is the appid for baidu translator init
+	AppID string `json:"appID"`
+
+	// Key is the appid for baidu translator init
+	Key string `json:"key"`
+}

--- a/config/weekly_report.go
+++ b/config/weekly_report.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The Pouch Robot Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// WeeklyReportConfig refers to auto weekly report config
+type WeeklyReportConfig struct {
+	// ReportDay representing which is the weekly report generation day.
+	ReportDay string `json:"reportDay"`
+
+	// ReportHour representing which is the weekly report generation time on ReportDay.
+	ReportHour int `json:"reportHour"`
+}

--- a/config_template.json
+++ b/config_template.json
@@ -1,0 +1,25 @@
+{
+    "owner": "%Your github owner%",
+    "repo": "%Your github repo%",
+    "httpListen": "0.0.0.0:6789",
+    "accessToken": "%Your github access token%",
+    "fetcher": {
+        "commitsGap": 20
+    },
+    "docGenerator": {
+        "rootDir": "",
+        "swaggerPath": "",
+        "APIDocPath": "",
+        "GenerationHour": 6
+    },
+    "translator": {
+        "baidu": {
+            "appID": "%Your baidu appid%",
+            "key": "%Your baidu key%"
+        }
+    },
+    "weeklyReport": {
+        "reportDay": "Friday",
+        "reportHour": 17
+    }
+}

--- a/main.go
+++ b/main.go
@@ -15,48 +15,45 @@
 package main
 
 import (
-	"github.com/pouchcontainer/pouchrobot/config"
+	"encoding/json"
+	"io/ioutil"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/pouchcontainer/pouchrobot/config"
 )
 
 func main() {
-	var cfg config.Config
-	var cmdServe = &cobra.Command{
+	var cmdCfg config.CmdConfig
+	cmdExecutor := &cobra.Command{
 		Use:  "An AI-based collaboration robot applied to open source project on GitHub",
 		Args: cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
+			configContent, err := ioutil.ReadFile(cmdCfg.ConfigFilePath)
+			if err != nil {
+				logrus.Fatal(err)
+				return
+			}
+			var cfg config.Config
+			err = json.Unmarshal(configContent, &cfg)
+			if err != nil {
+				logrus.Fatal(err)
+				return
+			}
 			s, err := NewServer(cfg)
 			if err != nil {
 				logrus.Fatal(err)
+				return
 			}
 			logrus.Fatal(s.Run())
 		},
 	}
-	cmdServe.SilenceUsage = true
-	cmdServe.SilenceErrors = true
+	cmdExecutor.SilenceUsage = true
+	cmdExecutor.SilenceErrors = true
 
-	flagSet := cmdServe.Flags()
-	flagSet.StringVarP(&cfg.Owner, "owner", "o", "", "GitHub username to which this robot connects")
-	flagSet.StringVarP(&cfg.Repo, "repo", "r", "", "GitHub code repository to which this robot connects")
-	flagSet.StringVarP(&cfg.HTTPListen, "listen", "l", "", "where does robot listen on")
-	flagSet.StringVarP(&cfg.AccessToken, "token", "t", "", "access token which identifies robot username in GitHub having write access on repo")
-	flagSet.IntVarP(&cfg.CommitsGap, "commits-gap", "c", 20, "commits gap between pull request and master branch; if the fact is beyond this number, request to rebase")
+	flagSet := cmdExecutor.Flags()
+	flagSet.StringVarP(&cmdCfg.ConfigFilePath, "config", "c", "config.json", "Config file path for robot")
 
-	// for weekly reporter
-	flagSet.StringVar(&cfg.ReportDay, "report-day", "Friday", "weekly report generation day of a week")
-	flagSet.IntVar(&cfg.ReportHour, "report-hour", 7, "weekly report generation hour on report-day")
-
-	// for doc generator
-	flagSet.StringVar(&cfg.RootDir, "root-dir", "", "specifies repo's root directory which is to generated docs")
-	flagSet.StringVar(&cfg.SwaggerPath, "swagger-path", "", "specifies where the swagger.yml file locates")
-	flagSet.StringVar(&cfg.APIDocPath, "api-doc-path", "", "specifies where to generate the doc file corresponding to swagger.yml")
-	flagSet.IntVar(&cfg.GenerationHour, "doc-generation-hour", 1, "specifies doc generation hour of every day.")
-
-	// baidu translator
-	flagSet.StringVar(&cfg.BaiduTranslatorAppID, "baidu-trans-appid", "", "specifies the appid for baidu translator")
-	flagSet.StringVar(&cfg.BaiduTranslatorKey, "baidu-trans-key", "", "specifies the key for baidu translator")
-
-	cmdServe.Execute()
+	cmdExecutor.Execute()
 }

--- a/server.go
+++ b/server.go
@@ -60,20 +60,20 @@ type Server struct {
 func NewServer(config config.Config) (*Server, error) {
 	ghClient := gh.NewClient(config.Owner, config.Repo, config.AccessToken)
 	translator := translators.NewBaiduTranslator(translators.BaiduTranslatorOptions{
-		Appid: config.BaiduTranslatorAppID,
-		Key:   config.BaiduTranslatorKey,
+		Appid: config.TranslatorConfig.BaiduConfig.AppID,
+		Key:   config.TranslatorConfig.BaiduConfig.Key,
 	})
 
-	docGenerator, err := docgenerator.New(ghClient, config.Owner, config.Repo, config.RootDir, config.SwaggerPath, config.APIDocPath, config.GenerationHour)
+	docGenerator, err := docgenerator.New(ghClient, config.Owner, config.Repo, config.DocGenerateConfig.RootDir, config.DocGenerateConfig.SwaggerPath, config.DocGenerateConfig.APIDocPath, config.DocGenerateConfig.GenerationHour)
 	if err != nil {
 		return nil, err
 	}
 	return &Server{
 		listenAddress: config.HTTPListen,
 		processor:     processor.New(ghClient, translator),
-		fetcher:       fetcher.New(ghClient, config.CommitsGap),
+		fetcher:       fetcher.New(ghClient, config.FetcherConfig.CommitsGap),
 		ciNotifier:    ci.New(ghClient),
-		reporter:      reporter.New(ghClient, config.ReportDay, config.ReportHour),
+		reporter:      reporter.New(ghClient, config.WeeklyReportConfig.ReportDay, config.WeeklyReportConfig.ReportHour),
 		docGenerator:  docGenerator,
 	}, nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/pouchcontainer/pouchrobot/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did
This PR convert commandline param to json config file. I split different config structure into separate files to make config with multiple levels and much more clear than at same level.

The only commandline param left is the config file path and provide a config template file to follow.

### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#fixes #90 

### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


