### PR TITLE
feature: make cli document general due to user's input command

### DIFF
--- a/config/doc_generate.go
+++ b/config/doc_generate.go
@@ -29,4 +29,8 @@ type DocGenerateConfig struct {
 	// GenerationHour represents doc generation time every day.
 	// Valid range is [0, 23].
 	GenerationHour int `json:"generationHour"`
+
+	// CliDocGeneratorCmd represents the command users input to generate cli
+	// related document.
+	CliDocGeneratorCmd string
 }

--- a/config_template.json
+++ b/config_template.json
@@ -10,7 +10,8 @@
         "rootDir": "",
         "swaggerPath": "",
         "APIDocPath": "",
-        "GenerationHour": 6
+        "GenerationHour": 6,
+        "CliDocGeneratorCmd": "make build-cli & ./bin/pouch gen-doc"
     },
     "translator": {
         "baidu": {

--- a/docgenerator/cli.go
+++ b/docgenerator/cli.go
@@ -23,20 +23,12 @@ import (
 // First, use newly built binary to execute `binary gen-doc` to generate Cli doc.
 // Second, git commit and push to github.
 // Third, use github to create a new pull request.
-//
-// FIXME: this is specific for PouchContainer
-// try to make it general.
 func (g *Generator) generateCliDoc() error {
-	// build a new binary cli client, since all cli doc is from newly built cli.
-	cmd := exec.Command("make", "build-cli")
+	// We execute the user input cli document generation command which is stored
+	// in Generator.CliDocGeneratorCmd
+	cmd := exec.Command("bash", "-c", g.CliDocGeneratorCmd)
 	if data, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to make client: output(%s), err(%v)", string(data), err)
-	}
-
-	// auto generate cli docs
-	cmd = exec.Command("./bin/pouch", "gen-doc")
-	if data, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to gen doc via cobra: output(%s), err(%v)", string(data), err)
+		return fmt.Errorf("failed to generate cli document via command(%s): output(%s), err(%v)", g.CliDocGeneratorCmd, string(data), err)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -18,10 +18,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/pouchcontainer/pouchrobot/config"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"github.com/pouchcontainer/pouchrobot/config"
 )
 
 func main() {
@@ -33,19 +33,18 @@ func main() {
 			configContent, err := ioutil.ReadFile(cmdCfg.ConfigFilePath)
 			if err != nil {
 				logrus.Fatal(err)
-				return
 			}
+
 			var cfg config.Config
-			err = json.Unmarshal(configContent, &cfg)
-			if err != nil {
+			if err := json.Unmarshal(configContent, &cfg); err != nil {
 				logrus.Fatal(err)
-				return
 			}
+
 			s, err := NewServer(cfg)
 			if err != nil {
 				logrus.Fatal(err)
-				return
 			}
+
 			logrus.Fatal(s.Run())
 		},
 	}

--- a/server.go
+++ b/server.go
@@ -64,7 +64,12 @@ func NewServer(config config.Config) (*Server, error) {
 		Key:   config.TranslatorConfig.BaiduConfig.Key,
 	})
 
-	docGenerator, err := docgenerator.New(ghClient, config.Owner, config.Repo, config.DocGenerateConfig.RootDir, config.DocGenerateConfig.SwaggerPath, config.DocGenerateConfig.APIDocPath, config.DocGenerateConfig.GenerationHour)
+	docGenerator, err := docgenerator.New(ghClient,
+		config.Owner, config.Repo,
+		config.DocGenerateConfig.RootDir, config.DocGenerateConfig.SwaggerPath, config.DocGenerateConfig.APIDocPath,
+		config.DocGenerateConfig.GenerationHour,
+		config.DocGenerateConfig.CliDocGeneratorCmd,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/pouchcontainer/pouchrobot/blob/master/CONTRIBUTING.md -->

### Ⅰ. Describe what this PR did

make cli document general due to user's input command.

```
// CliDocGeneratorCmd represents the command users input to generate cli
// related document.
CliDocGeneratorCmd string
```



### Ⅱ. Does this pull request fix one issue?
<!--If that, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
none


### Ⅲ. Why don't you add test cases (unit test/integration test)? (你真的觉得不需要加测试吗？)
pity


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


